### PR TITLE
Add GitHub actions ecosystem and react group to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,13 @@ updates:
       docusaurus:
         patterns:
           - '@docusaurus/*'
+      react:
+        patterns:
+          - react
+          - react-dom
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 10


### PR DESCRIPTION
- Added react group for update react & react-dom with same version;
- Added 'github-actions' package ecosystem for update actions.